### PR TITLE
Don't include pipeline libraries in changelog

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
-library 'ableton-utils@0.21'
-library 'groovylint@0.12'
+library(identifier: 'ableton-utils@0.21', changelog: false)
+library(identifier: 'groovylint@0.12', changelog: false)
 
 
 devToolsProject.run(


### PR DESCRIPTION
Aside from removing a bit of clutter from Jenkins build pages, this also
prevents commit authors of pipeline libraries from receiving build
failure notifications.
