### PR TITLE
Update to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ dependencies {
   compile 'org.codehaus.groovy:groovy-all:2.4.14'
 
   testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.14'
-  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
 }
 
 sourceSets {
@@ -26,4 +26,8 @@ sourceSets {
       srcDirs = ['test']
     }
   }
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
   compile 'com.cloudbees:groovy-cps:1+'
-  compile 'org.codehaus.groovy:groovy-all:2.4.12'
+  compile 'org.codehaus.groovy:groovy-all:2.4.14'
 
   testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.14'
   testImplementation 'junit:junit:4.13.2'

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ dependencies {
   compile 'com.cloudbees:groovy-cps:1+'
   compile 'org.codehaus.groovy:groovy-all:2.4.12'
 
-  testCompile 'com.lesfurets:jenkins-pipeline-unit:1.14'
-  testCompile 'junit:junit:4.13.2'
+  testImplementation 'com.lesfurets:jenkins-pipeline-unit:1.14'
+  testImplementation 'junit:junit:4.13.2'
 }
 
 sourceSets {

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -21,10 +21,7 @@ class PostgresDockerTest extends BasePipelineTest {
 
     this.script = loadScript('test/resources/EmptyPipeline.groovy')
     assertNotNull(script)
-    script.env = [
-      BUILD_ID: '1',
-      JOB_BASE_NAME: 'TestJob',
-    ]
+    script.env = [BUILD_ID: '1', JOB_BASE_NAME: 'TestJob']
 
     helper.addShMock('id -u', '1000', 0)
     helper.addShMock('id -g', '1000', 0)
@@ -92,9 +89,7 @@ class PostgresDockerTest extends BasePipelineTest {
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
 
     PostgresDocker postgres = new PostgresDocker(
-      script: script,
-      port: null,
-      randomSeed: 1,
+      script: script, port: null, randomSeed: 1
     )
     postgres.withDb('testdb') { port, id ->
       assertEquals(expectedPort, port)

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -31,7 +31,7 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test
-  void withDb() throws Exception {
+  void withDb() {
     String dataDir = 'tmpDirMocked/1/postgres/data'
     helper.addShMock("mkdir ${dataDir}", '', 0)
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
@@ -50,7 +50,7 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test(expected = Exception)
-  void withDbContainerFail() throws Exception {
+  void withDbContainerFail() {
     String dataDir = 'tmpDirMocked/1/postgres/data'
     helper.addShMock("mkdir ${dataDir}", '', 0)
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 1)
@@ -60,21 +60,21 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test(expected = AssertionError)
-  void withDbNoScript() throws Exception {
+  void withDbNoScript() {
     PostgresDocker postgres = new PostgresDocker()
 
     postgres.withDb('testdb') {}
   }
 
   @Test(expected = AssertionError)
-  void withDbNoDbName() throws Exception {
+  void withDbNoDbName() {
     PostgresDocker postgres = new PostgresDocker(script: script)
 
     postgres.withDb('') {}
   }
 
   @Test
-  void withDbCustomPort() throws Exception {
+  void withDbCustomPort() {
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
     PostgresDocker postgres = new PostgresDocker(script: script, port: 1234)
 
@@ -85,7 +85,7 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test
-  void withDbRandomPort() throws Exception {
+  void withDbRandomPort() {
     // Expected output given a seed of 1
     String expectedPort = '15873'
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
@@ -100,22 +100,22 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test(expected = AssertionError)
-  void withLinkedContainerNoImage() throws Exception {
+  void withLinkedContainerNoImage() {
     new PostgresDocker(script: script).withLinkedContainer(null, 'testdb') {}
   }
 
   @Test(expected = AssertionError)
-  void withLinkedContainerNoDbName() throws Exception {
+  void withLinkedContainerNoDbName() {
     new PostgresDocker(script: script).withLinkedContainer('mock-image', null) {}
   }
 
   @Test
-  void getRandomDigitString() throws Exception {
+  void getRandomDigitString() {
     assertEquals('0897531194', PostgresDocker.getRandomDigitString(10, 0))
   }
 
   @Test
-  void getRandomDigitStringIsRandom() throws Exception {
+  void getRandomDigitStringIsRandom() {
     // Ensure that allocating two objects in rapid succession will yield two different
     // random number generators. Naively seeding the random number generator with
     // System.currentTimeMillis() would not guarantee this to be the case.
@@ -129,7 +129,7 @@ class PostgresDockerTest extends BasePipelineTest {
   }
 
   @Test(expected = IllegalArgumentException)
-  void getRandomDigitStringInvalidLength() throws Exception {
+  void getRandomDigitStringInvalidLength() {
     PostgresDocker.getRandomDigitString(0, 0)
   }
 }

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -35,9 +35,9 @@ class PostgresDockerTest extends BasePipelineTest {
     String dataDir = 'tmpDirMocked/1/postgres/data'
     helper.addShMock("mkdir ${dataDir}", '', 0)
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
-
     PostgresDocker postgres = new PostgresDocker(script: script)
     boolean bodyExecuted = false
+
     int bodyResult = postgres.withDb('testdb') { port, id ->
       bodyExecuted = true
       assertEquals('5432', port)
@@ -54,28 +54,30 @@ class PostgresDockerTest extends BasePipelineTest {
     String dataDir = 'tmpDirMocked/1/postgres/data'
     helper.addShMock("mkdir ${dataDir}", '', 0)
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 1)
-
     PostgresDocker postgres = new PostgresDocker(script: script)
+
     postgres.withDb('testdb') {}
   }
 
   @Test(expected = AssertionError)
   void withDbNoScript() throws Exception {
     PostgresDocker postgres = new PostgresDocker()
+
     postgres.withDb('testdb') {}
   }
 
   @Test(expected = AssertionError)
   void withDbNoDbName() throws Exception {
     PostgresDocker postgres = new PostgresDocker(script: script)
+
     postgres.withDb('') {}
   }
 
   @Test
   void withDbCustomPort() throws Exception {
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
-
     PostgresDocker postgres = new PostgresDocker(script: script, port: 1234)
+
     postgres.withDb('testdb') { port, id ->
       assertEquals('1234', port)
       assertEquals('mock-container', id)
@@ -87,10 +89,10 @@ class PostgresDockerTest extends BasePipelineTest {
     // Expected output given a seed of 1
     String expectedPort = '15873'
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 0)
-
     PostgresDocker postgres = new PostgresDocker(
       script: script, port: null, randomSeed: 1
     )
+
     postgres.withDb('testdb') { port, id ->
       assertEquals(expectedPort, port)
       assertEquals('mock-container', id)
@@ -119,6 +121,7 @@ class PostgresDockerTest extends BasePipelineTest {
     // System.currentTimeMillis() would not guarantee this to be the case.
     PostgresDocker pd1 = new PostgresDocker(script: script)
     PostgresDocker pd2 = new PostgresDocker(script: script)
+
     assertNotEquals(
       pd1.getRandomDigitString(4, pd1.randomSeed),
       pd2.getRandomDigitString(4, pd2.randomSeed)

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -21,12 +21,10 @@ class PostgresDockerTest extends BasePipelineTest {
 
     this.script = loadScript('test/resources/EmptyPipeline.groovy')
     assertNotNull(script)
-    script.with {
-      env = [
-        BUILD_ID: '1',
-        JOB_BASE_NAME: 'TestJob',
-      ]
-    }
+    script.env = [
+      BUILD_ID: '1',
+      JOB_BASE_NAME: 'TestJob',
+    ]
 
     helper.addShMock('id -u', '1000', 0)
     helper.addShMock('id -g', '1000', 0)

--- a/test/com/ableton/PostgresDockerTest.groovy
+++ b/test/com/ableton/PostgresDockerTest.groovy
@@ -1,20 +1,21 @@
 package com.ableton
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertNotEquals
-import static org.junit.Assert.assertNotNull
-import static org.junit.Assert.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertThrows
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 
 class PostgresDockerTest extends BasePipelineTest {
   Object script
 
   @Override
-  @Before
+  @BeforeEach
   @SuppressWarnings('ThrowException')
   void setUp() {
     super.setUp()
@@ -49,28 +50,28 @@ class PostgresDockerTest extends BasePipelineTest {
     assertEquals(123, bodyResult)
   }
 
-  @Test(expected = Exception)
+  @Test
   void withDbContainerFail() {
     String dataDir = 'tmpDirMocked/1/postgres/data'
     helper.addShMock("mkdir ${dataDir}", '', 0)
     helper.addShMock("pg_isready -h \$DB_PORT_5432_TCP_ADDR", '', 1)
     PostgresDocker postgres = new PostgresDocker(script: script)
 
-    postgres.withDb('testdb') {}
+    assertThrows(Exception) { postgres.withDb('testdb') {} }
   }
 
-  @Test(expected = AssertionError)
+  @Test
   void withDbNoScript() {
     PostgresDocker postgres = new PostgresDocker()
 
-    postgres.withDb('testdb') {}
+    assertThrows(AssertionError) { postgres.withDb('testdb') {} }
   }
 
-  @Test(expected = AssertionError)
+  @Test
   void withDbNoDbName() {
     PostgresDocker postgres = new PostgresDocker(script: script)
 
-    postgres.withDb('') {}
+    assertThrows(AssertionError) { postgres.withDb('') {} }
   }
 
   @Test
@@ -99,14 +100,18 @@ class PostgresDockerTest extends BasePipelineTest {
     }
   }
 
-  @Test(expected = AssertionError)
+  @Test
   void withLinkedContainerNoImage() {
-    new PostgresDocker(script: script).withLinkedContainer(null, 'testdb') {}
+    assertThrows(AssertionError) {
+      new PostgresDocker(script: script).withLinkedContainer(null, 'testdb') {}
+    }
   }
 
-  @Test(expected = AssertionError)
+  @Test
   void withLinkedContainerNoDbName() {
-    new PostgresDocker(script: script).withLinkedContainer('mock-image', null) {}
+    assertThrows(AssertionError) {
+      new PostgresDocker(script: script).withLinkedContainer('mock-image', null) {}
+    }
   }
 
   @Test
@@ -128,8 +133,8 @@ class PostgresDockerTest extends BasePipelineTest {
     )
   }
 
-  @Test(expected = IllegalArgumentException)
+  @Test
   void getRandomDigitStringInvalidLength() {
-    PostgresDocker.getRandomDigitString(0, 0)
+    assertThrows(IllegalArgumentException) { PostgresDocker.getRandomDigitString(0, 0) }
   }
 }


### PR DESCRIPTION
- Cleanup: remove redundant "with"
- Cleanup: condense multi-line statements
- Cleanup: add newlines between test sections
- Cleanup: remove redundant "throws Exception"
- Use testImplementation instead of testCompile
- Bump groovy-all to 2.4.14
- Update to JUnit 5
