### PR TITLE
Remove unnecessary failFast argument to parallel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ library(identifier: 'groovylint@0.13', changelog: false)
 
 devToolsProject.run(
   test: { data ->
-    parallel(failFast: false,
+    parallel(
       groovydoc: {
         data['docs'] = groovydoc.generate()
       },


### PR DESCRIPTION
`false` is already the default value for this argument.